### PR TITLE
MediaCodecsXmlParser: Make limit logging less verbose

### DIFF
--- a/media/libstagefright/xmlparser/MediaCodecsXmlParser.cpp
+++ b/media/libstagefright/xmlparser/MediaCodecsXmlParser.cpp
@@ -1307,7 +1307,7 @@ status_t MediaCodecsXmlParser::Impl::Parser::addLimit(const char **attrs) {
 void MediaCodecsXmlParser::Impl::State::addDetail(
         const std::string &key, const std::string &value) {
     CHECK(inType());
-    ALOGI("limit: %s = %s", key.c_str(), value.c_str());
+    ALOGV("limit: %s = %s", key.c_str(), value.c_str());
     const StringSet &variants = mVariantsStack.back();
     if (variants.empty()) {
         type()[key] = value;


### PR DESCRIPTION
Change ALOGI to ALOGV for logging "limit:".

Test: adb shell stagefright -i

Bug: 142912282
Change-Id: I74fef7d7169db034f4ebaa662218725c53fbf80c