### PR TITLE
Fix high battery drain after using flashlight

### DIFF
--- a/services/camera/libcameraservice/CameraFlashlight.cpp
+++ b/services/camera/libcameraservice/CameraFlashlight.cpp
@@ -587,7 +587,7 @@ status_t CameraHardwareInterfaceFlashControl::disconnectCameraDevice() {
     }
     mDevice->setPreviewWindow(NULL);
     mDevice->release();
-    mDevice = NULL;
+    mDevice.clear();
 
     return OK;
 }


### PR DESCRIPTION
After turning off the flashlight via the tile, the camera is kept open, preventing the device from entering deep sleep (and destroying battery life).

Properly close the camera after turning off the flashlight in order to fix the high battery drain.

Change-Id: Ib3b1fa77f8f1d22b94ab969dff834015a7ebe59b
Signed-off-by: adiatul16 <adiatul16@gmail.com>