### PR TITLE
camera/media: Support legacy HALv1 camera in mediaserver

### DIFF
--- a/media/mediaserver/Android.bp
+++ b/media/mediaserver/Android.bp
@@ -28,6 +28,9 @@ cc_library_static {
 
 cc_binary {
     name: "mediaserver",
+    defaults: [
+        "camera_in_mediaserver_defaults",
+    ],
 
     srcs: ["main_mediaserver.cpp"],
 

--- a/media/mediaserver/main_mediaserver.cpp
+++ b/media/mediaserver/main_mediaserver.cpp
@@ -26,6 +26,10 @@
 #include "RegisterExtensions.h"
 
 // from LOCAL_C_INCLUDES
+#ifdef NO_CAMERA_SERVER
+#include "CameraService.h"
+#include <hidl/HidlTransportSupport.h>
+#endif
 #include "MediaPlayerService.h"
 #include "ResourceManagerService.h"
 
@@ -35,11 +39,19 @@ int main(int argc __unused, char **argv __unused)
 {
     signal(SIGPIPE, SIG_IGN);
 
+#ifdef NO_CAMERA_SERVER
+    // Set 3 threads for HIDL calls
+    hardware::configureRpcThreadpool(3, /*willjoin*/ false);
+#endif
+
     sp<ProcessState> proc(ProcessState::self());
     sp<IServiceManager> sm(defaultServiceManager());
     ALOGI("ServiceManager: %p", sm.get());
     MediaPlayerService::instantiate();
     ResourceManagerService::instantiate();
+#ifdef NO_CAMERA_SERVER
+    CameraService::instantiate();
+#endif
     registerExtensions();
     ::android::hardware::configureRpcThreadpool(16, false);
     ProcessState::self()->startThreadPool();

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -41,6 +41,7 @@ cc_library_shared {
         "camera_needs_client_info_lib_defaults",
         "qti_camera_device_defaults",
         "needs_camera_boottime_defaults",
+        "no_cameraserver_defaults",
     ],
 
     // Camera service source

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -1037,7 +1037,11 @@ int32_t CameraService::mapToInterface(StatusInternal status) {
 Status CameraService::initializeShimMetadata(int cameraId) {
     int uid = CameraThreadState::getCallingUid();
 
+#ifdef NO_CAMERA_SERVER
+    String16 internalPackageName("media");
+#else
     String16 internalPackageName("cameraserver");
+#endif
     String8 id = String8::format("%d", cameraId);
     Status ret = Status::ok();
     sp<Client> tmp = nullptr;
@@ -1119,7 +1123,9 @@ Status CameraService::getLegacyParametersLazy(int cameraId,
 static bool isTrustedCallingUid(uid_t uid) {
     switch (uid) {
         case AID_MEDIA:        // mediaserver
+#ifndef NO_CAMERA_SERVER
         case AID_CAMERASERVER: // cameraserver
+#endif
         case AID_RADIO:        // telephony
             return true;
         default:
@@ -1252,6 +1258,7 @@ Status CameraService::validateClientPermissionsLocked(const String8& cameraId,
                 clientName8.string(), clientUid, clientPid, cameraId.string());
     }
 
+#ifndef NO_CAMERA_SERVER
     // Make sure the UID is in an active state to use the camera
     if (!mUidPolicy->isUidActive(callingUid, String16(clientName8))) {
         int32_t procState = mUidPolicy->getProcState(callingUid);
@@ -1263,6 +1270,7 @@ Status CameraService::validateClientPermissionsLocked(const String8& cameraId,
                 clientName8.string(), clientUid, clientPid, cameraId.string(),
                 callingUid, procState);
     }
+#endif
 
     // If sensor privacy is enabled then prevent access to the camera
     if (mSensorPrivacyPolicy->isSensorPrivacyEnabled()) {


### PR DESCRIPTION
Pre 7.0 camera HALv1 can not share its video buffers
across different processes, which requires us to
disable this security feature.

This change allows devices to re-integrate cameraserver
and mediaserver which is the first step to support older
prebuilt camera HALs. A follow-up change will add back
support for legacy buffer handling.

To enable:
TARGET_HAS_LEGACY_CAMERA_HAL1 := true
media.stagefright.legacyencoder=true
media.stagefright.less-secure=true

Change-Id: I4fcc8907ea235b7e83af26122b4da97ca5117816

mediaserver: Update HALv1 dependencies for 8.1.0

 * Add libcameraservice shared library dependency
 * Add new libgui, android.hardware.camera.common@1.0
    and android.hardware.camera.provider@2.4 shared
    libraries and exported headers HAL dependencies

 * Match cameraserver HIDL additions and dependencies

 * When TARGET_HAS_LEGACY_CAMERA_HAL1 is set, the mediaserver
    includes CameraService.h but exported headers are missing

 * Error upon build due to missing libcameraservice linkage:
    fatal error: 'android/hardware/BnCameraService.h' file not found

mediaserver: Update HALv1 dependencies for 9.0.0

 * Disable active state UID validation for HAL1 devices

Change-Id: Ib6bb8a4e9ef18606c64e2dff13504d2eeaac13b1
Signed-off-by: Adrian DC <radian.dc@gmail.com>