### PR TITLE
HACK: libcameraservice: Make system cameras available to all camera apps

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -631,8 +631,7 @@ void CameraService::onTorchStatusChangedLocked(const String8& cameraId,
 }
 
 static bool hasPermissionsForSystemCamera(int callingPid, int callingUid) {
-    return checkPermission(sSystemCameraPermission, callingPid, callingUid) &&
-            checkPermission(sCameraPermission, callingPid, callingUid);
+    return checkPermission(sCameraPermission, callingPid, callingUid);
 }
 
 Status CameraService::getNumberOfCameras(int32_t type, int32_t* numCameras) {


### PR DESCRIPTION
 * big brained realmeme decided to move aux cams to "system-only cameras"
   utilizing the new permission introduced in android 11, thereby breaking
   aux cams in 3rd party camera apps like gcam

 * lets avoid this and make system camera accessible to all camera apps;
   legacy apps still wont break because of the aux cams check in fwb

Test: manual, aux cameras accessible by gcam on realme X3
Change-Id: I5db53ffe91a8c28972f1c58bd228cb0f79d7183a
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>