### PR TITLE
Camera: Update crop info in onHeicFormatChanged

### DIFF
--- a/services/camera/libcameraservice/api2/HeicCompositeStream.cpp
+++ b/services/camera/libcameraservice/api2/HeicCompositeStream.cpp
@@ -441,6 +441,10 @@ void HeicCompositeStream::onHeicFormatChanged(sp<AMessage>& newFormat) {
             newFormat->setInt32(KEY_TILE_HEIGHT, mGridHeight);
             newFormat->setInt32(KEY_GRID_ROWS, mGridRows);
             newFormat->setInt32(KEY_GRID_COLUMNS, mGridCols);
+            int32_t left, top, right, bottom;
+            if (newFormat->findRect("crop", &left, &top, &right, &bottom)) {
+                newFormat->setRect("crop", 0, 0, mOutputWidth - 1, mOutputHeight - 1);
+            }
         }
     }
     newFormat->setInt32(KEY_IS_DEFAULT, 1 /*isPrimary*/);


### PR DESCRIPTION
If the AMessage passed in by onHeicFormatChanged contains crop,
the crop size needs to be updated together with the tile size.

Bug: 228973357
Test: vendor testing
Change-Id: I6ab5a6d70a3adcbe7785aa18e388d0186acf939b