### PR TITLE
libcameraservice: add TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -38,6 +38,7 @@ license {
 cc_library_shared {
     name: "libcameraservice",
     defaults: [
+        "camera_needs_client_info_lib_defaults",
         "needs_camera_boottime_defaults",
         "uses_oplus_camera_defaults",
         "uses_nothing_camera_defaults",

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -78,6 +78,10 @@
 #include "utils/CameraThreadState.h"
 #include "utils/CameraServiceProxyWrapper.h"
 
+#ifdef CAMERA_NEEDS_CLIENT_INFO_LIB
+#include <vendor/oneplus/hardware/camera/1.0/IOnePlusCameraProvider.h>
+#endif
+
 namespace {
     const char* kPermissionServiceName = "permission";
 }; // namespace anonymous
@@ -95,6 +99,9 @@ using hardware::camera2::ICameraInjectionCallback;
 using hardware::camera2::ICameraInjectionSession;
 using hardware::camera2::utils::CameraIdAndSessionConfiguration;
 using hardware::camera2::utils::ConcurrentCameraIdCombination;
+#ifdef CAMERA_NEEDS_CLIENT_INFO_LIB
+using ::vendor::oneplus::hardware::camera::V1_0::IOnePlusCameraProvider;
+#endif
 
 // ----------------------------------------------------------------------------
 // Logging support -- this is for debugging only
@@ -132,6 +139,9 @@ static const String16 sCameraOpenCloseListenerPermission(
 static const String16
         sCameraInjectExternalCameraPermission("android.permission.CAMERA_INJECT_EXTERNAL_CAMERA");
 const char *sFileName = "lastOpenSessionDumpFile";
+#ifdef CAMERA_NEEDS_CLIENT_INFO_LIB
+static const sp<IOnePlusCameraProvider> gVendorCameraProviderService = IOnePlusCameraProvider::getService();
+#endif
 static constexpr int32_t kSystemNativeClientScore = resource_policy::PERCEPTIBLE_APP_ADJ;
 static constexpr int32_t kSystemNativeClientState =
         ActivityManager::PROCESS_STATE_PERSISTENT_UI;
@@ -3506,6 +3516,10 @@ status_t CameraService::BasicClient::startCameraOps() {
 
     // Notify listeners of camera open/close status
     sCameraService->updateOpenCloseStatus(mCameraIdStr, true/*open*/, mClientPackageName);
+
+#ifdef CAMERA_NEEDS_CLIENT_INFO_LIB
+    gVendorCameraProviderService->setPackageName(String8(mClientPackageName).string());
+#endif
 
     return OK;
 }


### PR DESCRIPTION
Directly set camera package name by using OnePlusCameraProvider service.

Signed-off-by: firebird11 <hbgassel@gmail.com>
____
Pulled directly from 12.1 branch.

Needed for 60fps video recording on oneplus/sdm845 using OnePlus Camera v3.14.40 (the latest release available for enchilada & fajita). Without it, setting 1080p60 or 4Kp60 video record modes changes the shutter speed to 1/60th for less motion blur, but video is still only captured at 30fps.

See also soong BoardConfig flag in android_vendor_crdroid.