### PR TITLE
Revert "MediaCodec: Don't disconnectFromSurface when it is using"

### DIFF
--- a/media/libstagefright/MediaCodec.cpp
+++ b/media/libstagefright/MediaCodec.cpp
@@ -4109,7 +4109,7 @@ void MediaCodec::onMessageReceived(const sp<AMessage> &msg) {
                                     err = mCodec->setSurface(surface);
                                 }
                             }
-                            if (err == OK && mSurface->getIGraphicBufferProducer() == nullptr) {
+                            if (err == OK) {
                                 (void)disconnectFromSurface();
                                 mSurface = surface;
                             }


### PR DESCRIPTION
This reverts commit 76ec0073140e224a1fd8afd6275b985c77ed2935.

Causes errors with exoplayer2 not being able to reconnect to surfaces that it expected to be released.
___

Reverting that commit fixes the errors reported in https://github.com/crdroidandroid/issue_tracker/issues/35

Now you can navigate away from the fullscreen player without stopping playback & generating errors in NewPipe (playback switches to background audio-only playback without interruption, as intended).