### PR TITLE
Codec2: Extend the queue empty work hack to MTK decoders too

### DIFF
--- a/media/codec2/sfplugin/CCodecBufferChannel.cpp
+++ b/media/codec2/sfplugin/CCodecBufferChannel.cpp
@@ -206,7 +206,7 @@ void CCodecBufferChannel::setComponent(
     mComponent = component;
     mComponentName = component->getName() + StringPrintf("#%d", int(uintptr_t(component.get()) % 997));
     mName = mComponentName.c_str();
-    std::regex pattern{"c2\\.qti\\..*\\.decoder.*"};
+    std::regex pattern{"c2\\.(mtk|qti)\\..*\\.decoder.*"};
     mIsHWDecoder = std::regex_match(mComponentName, pattern);
 }
 


### PR DESCRIPTION
Change-Id: I1a1ff62e4f2b68922974ea6492a501ca65a13c5a