### PR TITLE
libcameraservice: Fixup camera package name additions for 14.0 QPR2

### DIFF
--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -28,6 +28,9 @@ cc_binary {
 
     defaults: [
         "libcameraservice_deps",
+        "camera_package_name_defaults",
+        "camera_needs_client_info_lib_defaults",
+        "camera_needs_client_info_lib_oplus_defaults",
     ],
 
     header_libs: [

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -4220,7 +4220,7 @@ status_t CameraService::BasicClient::startCameraOps() {
     sCameraService->updateOpenCloseStatus(mCameraIdStr, true/*open*/, mClientPackageName);
 
 #if defined (CAMERA_NEEDS_CLIENT_INFO_LIB) || defined (CAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS)
-    gVendorCameraProviderService->setPackageName(String8(mClientPackageName).string());
+    gVendorCameraProviderService->setPackageName(mClientPackageName.c_str());
 #endif
 
     return OK;


### PR DESCRIPTION
- Fixes build-time linking when utilizing build flags to support MIUI and OnePlus prebuilt camera apks

- Replace usage of String8() with c_str()

_____

Please let me know if this breaks anything on devices that don't use any custom client package names / client info lib build flags.