### PR TITLE
fixup! "libcameraservice: add TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB"

### DIFF
--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -28,6 +28,9 @@ cc_binary {
 
     defaults: [
         "libcameraservice_deps",
+        "camera_package_name_defaults",
+        "camera_needs_client_info_lib_defaults",
+        "camera_needs_client_info_lib_oplus_defaults",
     ],
 
     header_libs: [


### PR DESCRIPTION
Fixes build-time linking error when utilizing TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB build flags to support MIUI and OnePlus prebuilt camera apks.

If you set that flag in device tree, and try to do a clean build, it will fail (see attached error.log).
I know @ShevT has said before that it "shouldn't" be necessary, but the source DOES NOT COMPILE without these additions.

Adding these lines to camera/cameraserver/Android.bp fixes build.

Will this commit cause breakage for other devices which DON'T use the `TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB` build flag?
Please someone respond to that question... 😅 
[error.log](https://github.com/crdroidandroid/android_frameworks_av/files/15445355/error.log)
