### PR TITLE
Fixup! libcameraservice: add TARGET_CAMERA_NEEDS_CLIENT_INFO_LIB

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -4466,7 +4466,7 @@ status_t CameraService::BasicClient::notifyCameraOpening() {
             mSharedMode);
 
 #if defined (CAMERA_NEEDS_CLIENT_INFO_LIB) || defined (CAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS)
-    gVendorCameraProviderService->setPackageName(mClientPackageName.c_str());
+    gVendorCameraProviderService->setPackageName(getPackageName().c_str());
 #endif
 
     return OK;


### PR DESCRIPTION
* Needed after cid I1aa27ae66ba897752fdbac43b2a6f9c94301ae71 "Propagate clientAttribution to CameraService::BasicClient"

Fixes compile error when CAMERA_NEEDS_CLIENT_INFO_LIB flag is set, due to mClientPackageName no longer being part of the CameraService::BasicClient constructor.