### PR TITLE
15.0 soong config variable fixes

### DIFF
--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -53,16 +53,22 @@ cc_binary {
         "android.hardware.camera.device@3.2",
         "android.hardware.camera.device@3.4",
     ],
+
     static_libs: [
         "libcameraservice",
     ],
+
     compile_multilib: "first",
+
     cflags: [
         "-Wall",
         "-Wextra",
         "-Werror",
         "-Wno-unused-parameter",
-    ],
+    ] + select(soong_config_variable("camera", "package_name"), {
+        any @ flag_val: ["-DCAMERA_PACKAGE_NAME=\"" + flag_val + "\""],
+        default: [],
+    }),
 
     init_rc: ["cameraserver.rc"],
 

--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -52,7 +52,13 @@ cc_binary {
         "android.hardware.camera.device@1.0",
         "android.hardware.camera.device@3.2",
         "android.hardware.camera.device@3.4",
-    ],
+    ] + select(soong_config_variable("camera", "needs_client_info_lib"), {
+        "true": ["//hardware/oneplus:vendor.oneplus.hardware.camera@1.0"],
+        default: [],
+    }) + select(soong_config_variable("camera", "needs_client_info_lib_oplus"), {
+        "true": ["vendor.oplus.hardware.cameraMDM@2.0"],
+        default: [],
+    }),
 
     static_libs: [
         "libcameraservice",

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -237,7 +237,7 @@ cc_library {
         "-Werror",
         "-Wno-ignored-qualifiers",
     ] + select(soong_config_variable("camera", "package_name"), {
-        any @ flag_val: ["-DTARGET_CAMERA_PACKAGE_NAME=" + flag_val],
+        any @ flag_val: ["-DCAMERA_PACKAGE_NAME=\"" + flag_val + "\""],
         default: [],
     }) + select(soong_config_variable("camera", "needs_client_info_lib"), {
         "true": ["-DTARGET_CAMERA_NEEDS_CLIENT_INFO_LIB"],

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -215,6 +215,15 @@ cc_library {
         "libmediametrics_headers",
     ],
 
+    shared_libs: [
+    ] + select(soong_config_variable("camera", "needs_client_info_lib"), {
+        "true": ["//hardware/oneplus:vendor.oneplus.hardware.camera@1.0"],
+        default: [],
+    }) + select(soong_config_variable("camera", "needs_client_info_lib_oplus"), {
+        "true": ["vendor.oplus.hardware.cameraMDM@2.0"],
+        default: [],
+    }),
+
     export_shared_lib_headers: [
         "libbinder",
         "libactivitymanager_aidl",
@@ -240,10 +249,10 @@ cc_library {
         any @ flag_val: ["-DCAMERA_PACKAGE_NAME=\"" + flag_val + "\""],
         default: [],
     }) + select(soong_config_variable("camera", "needs_client_info_lib"), {
-        "true": ["-DTARGET_CAMERA_NEEDS_CLIENT_INFO_LIB"],
+        "true": ["-DCAMERA_NEEDS_CLIENT_INFO_LIB"],
         default: [],
     }) + select(soong_config_variable("camera", "needs_client_info_lib_oplus"), {
-        "true": ["-DTARGET_CAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS"],
+        "true": ["-DCAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS"],
         default: [],
     }) + select(soong_config_variable("camera", "libcameraservice_ext_lib"), {
         any @ flag_val: ["-DTARGET_CAMERA_SERVICE_EXT_LIB=" + flag_val],

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -255,9 +255,10 @@ cc_library {
         "true": ["-DCAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS"],
         default: [],
     }) + select(soong_config_variable("camera", "libcameraservice_ext_lib"), {
-        any @ flag_val: ["-DTARGET_CAMERA_SERVICE_EXT_LIB=" + flag_val],
+        any @ flag_val: ["-DTARGET_CAMERA_SERVICE_EXT_LIB=\"" + flag_val + "\""],
         default: [],
     }),
+
     whole_static_libs: select(soong_config_variable("camera", "libcameraservice_ext_lib"), {
         any @ flag_val: [flag_val],
         default: ["libcameraservice_ext_lib"],


### PR DESCRIPTION
Fixed broken client camera package name injection & enablement of client info lib cflags.

Third commit ("camera: Fixup2! Add extension to control torch light strength") probably not needed since ShEV said it was already working correctly but if it doesn't break anything then it's nice to tidy up & wrap strings we're passing as environment variables, yeah?
I can't test that last one tho, don't have torch control ext lib for my device yet myself.