### PR TITLE
libcameraservice: support disabling torch control support

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -245,23 +245,9 @@ cc_library {
         "-Wextra",
         "-Werror",
         "-Wno-ignored-qualifiers",
-    ] + select(soong_config_variable("camera", "package_name"), {
-        any @ flag_val: ["-DCAMERA_PACKAGE_NAME=\"" + flag_val + "\""],
+    ] + select(soong_config_variable("cameraservice", "disable_torch_control"), {
+        any @ value: ["-DDISABLE_TORCH_CONTROL"],
         default: [],
-    }) + select(soong_config_variable("camera", "needs_client_info_lib"), {
-        "true": ["-DCAMERA_NEEDS_CLIENT_INFO_LIB"],
-        default: [],
-    }) + select(soong_config_variable("camera", "needs_client_info_lib_oplus"), {
-        "true": ["-DCAMERA_NEEDS_CLIENT_INFO_LIB_OPLUS"],
-        default: [],
-    }) + select(soong_config_variable("camera", "libcameraservice_ext_lib"), {
-        any @ flag_val: ["-DTARGET_CAMERA_SERVICE_EXT_LIB=\"" + flag_val + "\""],
-        default: [],
-    }),
-
-    whole_static_libs: select(soong_config_variable("camera", "libcameraservice_ext_lib"), {
-        any @ flag_val: [flag_val],
-        default: ["libcameraservice_ext_lib"],
     }),
 }
 

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -2982,11 +2982,15 @@ Status CameraService::turnOnTorchWithStrengthLevel(const std::string& unresolved
         Mutex::Autolock al(mTorchUidMapMutex);
         updateTorchUidMapLocked(cameraId, uid);
     }
+#ifdef DISABLE_TORCH_CONTROL
+    bool shouldSkipTorchStrengthUpdates = false;
+    status_t err = mFlashlight->setTorchMode(cameraId, (torchStrength > 0) ? 1 : 0);
+#else
     // Check if the current torch strength level is same as the new one.
     bool shouldSkipTorchStrengthUpdates = mCameraProviderManager->shouldSkipTorchStrengthUpdate(
             cameraId, torchStrength);
-
     status_t err = mFlashlight->turnOnTorchWithStrengthLevel(cameraId, torchStrength);
+#endif
 
     if (err != OK) {
         int32_t errorCode;


### PR DESCRIPTION
On some devices such as OnePlus 12, newer blobs have a strange crash which is entirely proprietary stacktraced with torch control support, and Oplus stock disables in platform.

We previously had a hack to manually implement it in an extension, but this device was also the only one that had other issues with it.

Additionally, >2.3 aidl isn't expected to lack this support. So this hack simply always uses the same strength (legacy path), and does not use torch control.