### PR TITLE
Revert "MultiAccessUnit reflector helper allocated once per Component…

### DIFF
--- a/media/codec2/hal/aidl/ComponentStore.cpp
+++ b/media/codec2/hal/aidl/ComponentStore.cpp
@@ -153,13 +153,6 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
         mParamReflectors.push_back(paramReflector);
     }
 #endif
-    // MultiAccessUnit reflector helper is allocated once per store.
-    // All components in this store can reuse this reflector helper.
-    if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
-        std::shared_ptr<C2ReflectorHelper> helper = std::make_shared<C2ReflectorHelper>();
-        mParamReflectors.push_back(helper);
-        mMultiAccessUnitReflector = helper;
-    }
 
     // Retrieve supported parameters from store
     using namespace std::placeholders;
@@ -247,9 +240,11 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 // param reflectors. Currently filters work on video domain only,
                 // and the MultiAccessUnitHelper is only enabled on audio domain;
                 // thus we pass the component's param reflector, which is mParamReflectors[0].
+                std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
-                        mMultiAccessUnitReflector);
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
             }
         }
     }

--- a/media/codec2/hal/aidl/include/codec2/aidl/ComponentStore.h
+++ b/media/codec2/hal/aidl/include/codec2/aidl/ComponentStore.h
@@ -127,9 +127,6 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
-    // Reflector helper for MultiAccessUnitHelper
-    std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
-
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;
     std::set<C2String> mLoadedInterfaces;

--- a/media/codec2/hal/hidl/1.0/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.0/utils/ComponentStore.cpp
@@ -149,14 +149,6 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
-    // MultiAccessUnit reflector helper is allocated once per store.
-    // All components in this store can reuse this reflector helper.
-    if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
-        std::shared_ptr<C2ReflectorHelper> helper = std::make_shared<C2ReflectorHelper>();
-        mParamReflectors.push_back(helper);
-        mMultiAccessUnitReflector = helper;
-    }
-
     // Retrieve supported parameters from store
     using namespace std::placeholders;
     mInit = mConfigurable->init(mParameterCache);
@@ -239,9 +231,12 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 }
             }
             if (!isComponentSupportsLargeAudioFrame) {
+                std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
-                        mMultiAccessUnitReflector);
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
+
             }
         }
     }

--- a/media/codec2/hal/hidl/1.0/utils/include/codec2/hidl/1.0/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.0/utils/include/codec2/hidl/1.0/ComponentStore.h
@@ -131,9 +131,6 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
-    // Reflector helper for MultiAccessUnitHelper
-    std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
-
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;
     std::set<C2String> mLoadedInterfaces;

--- a/media/codec2/hal/hidl/1.1/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.1/utils/ComponentStore.cpp
@@ -149,14 +149,6 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
-    // MultiAccessUnit reflector helper is allocated once per store.
-    // All components in this store can reuse this reflector helper.
-    if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
-        std::shared_ptr<C2ReflectorHelper> helper = std::make_shared<C2ReflectorHelper>();
-        mParamReflectors.push_back(helper);
-        mMultiAccessUnitReflector = helper;
-    }
-
     // Retrieve supported parameters from store
     using namespace std::placeholders;
     mInit = mConfigurable->init(mParameterCache);
@@ -238,10 +230,13 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                     break;
                 }
             }
+
             if (!isComponentSupportsLargeAudioFrame) {
+                std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
-                        mMultiAccessUnitReflector);
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
             }
         }
     }

--- a/media/codec2/hal/hidl/1.1/utils/include/codec2/hidl/1.1/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.1/utils/include/codec2/hidl/1.1/ComponentStore.h
@@ -139,9 +139,6 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
-    // Reflector helper for MultiAccessUnitHelper
-    std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
-
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;
     std::set<C2String> mLoadedInterfaces;

--- a/media/codec2/hal/hidl/1.2/utils/ComponentStore.cpp
+++ b/media/codec2/hal/hidl/1.2/utils/ComponentStore.cpp
@@ -149,14 +149,6 @@ ComponentStore::ComponentStore(const std::shared_ptr<C2ComponentStore>& store)
     }
 #endif
 
-    // MultiAccessUnit reflector helper is allocated once per store.
-    // All components in this store can reuse this reflector helper.
-    if (MultiAccessUnitHelper::isEnabledOnPlatform()) {
-        std::shared_ptr<C2ReflectorHelper> helper = std::make_shared<C2ReflectorHelper>();
-        mParamReflectors.push_back(helper);
-        mMultiAccessUnitReflector = helper;
-    }
-
     // Retrieve supported parameters from store
     using namespace std::placeholders;
     mInit = mConfigurable->init(mParameterCache);
@@ -239,9 +231,11 @@ std::shared_ptr<MultiAccessUnitInterface> ComponentStore::tryCreateMultiAccessUn
                 }
             }
             if (!isComponentSupportsLargeAudioFrame) {
+                std::shared_ptr<C2ReflectorHelper> multiAccessReflector(new C2ReflectorHelper());
                 multiAccessUnitIntf = std::make_shared<MultiAccessUnitInterface>(
                         c2interface,
-                        mMultiAccessUnitReflector);
+                        multiAccessReflector);
+                mParamReflectors.push_back(multiAccessReflector);
             }
         }
     }

--- a/media/codec2/hal/hidl/1.2/utils/include/codec2/hidl/1.2/ComponentStore.h
+++ b/media/codec2/hal/hidl/1.2/utils/include/codec2/hidl/1.2/ComponentStore.h
@@ -146,9 +146,6 @@ protected:
     std::shared_ptr<C2ComponentStore> mStore;
     std::vector<std::shared_ptr<C2ParamReflector>> mParamReflectors;
 
-    // Reflector helper for MultiAccessUnitHelper
-    std::shared_ptr<C2ReflectorHelper> mMultiAccessUnitReflector;
-
     std::map<C2Param::CoreIndex, std::shared_ptr<C2StructDescriptor>> mStructDescriptors;
     std::set<C2Param::CoreIndex> mUnsupportedStructDescriptors;
     std::set<C2String> mLoadedInterfaces;


### PR DESCRIPTION
…Store"

Breaks dolby decoders

This reverts commit 07b6b1570b4d4b77bfd5ec12aa56dda2e449ee6b.