### PR TITLE
fixup! issue: After connecting the Bluetooth earphones and projecting…

### DIFF
--- a/services/audiopolicy/common/managerdefinitions/include/DeviceDescriptor.h
+++ b/services/audiopolicy/common/managerdefinitions/include/DeviceDescriptor.h
@@ -58,10 +58,6 @@ public:
         mCurrentEncodedFormat = format;
     }
 
-    void setDeviceConnectState(bool connected){
-        mIsConnected = connected;
-    }
-
     bool equals(const sp<DeviceDescriptor>& other) const;
 
     bool hasCurrentEncodedFormat() const;
@@ -111,7 +107,6 @@ private:
     }
 
     std::string mTagName; // Unique human readable identifier for a device port found in conf file.
-    bool                mIsConnected = false;
     audio_format_t      mCurrentEncodedFormat;
     bool                mIsDynamic = false;
     std::string         mDeclaredAddress; // Original device address

--- a/services/audiopolicy/common/managerdefinitions/src/DeviceDescriptor.cpp
+++ b/services/audiopolicy/common/managerdefinitions/src/DeviceDescriptor.cpp
@@ -106,10 +106,6 @@ bool DeviceDescriptor::hasCurrentEncodedFormat() const
     if (mEncodedFormats.empty()) {
         return true;
     }
-    if(device_has_encoding_capability(type()) && !mIsConnected) {
-        ALOGD("%s: mIsConnected is false", __func__);
-        return true;
-    }
 
     return (mCurrentEncodedFormat != AUDIO_FORMAT_DEFAULT);
 }

--- a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
@@ -271,7 +271,6 @@ status_t AudioPolicyManager::setDeviceConnectionStateInt(const sp<DeviceDescript
 
             // Populate encapsulation information when a output device is connected.
             device->setEncapsulationInfoFromHal(mpClientInterface);
-            device->setDeviceConnectState(true);
 
             // outputs should never be empty here
             ALOG_ASSERT(outputs.size() != 0, "setDeviceConnectionState():"
@@ -301,13 +300,6 @@ status_t AudioPolicyManager::setDeviceConnectionStateInt(const sp<DeviceDescript
 
             // Send Disconnect to HALs
             broadcastDeviceConnectionState(device, media::DeviceConnectedState::DISCONNECTED);
-
-            // Reset active device codec
-            device->setEncodedFormat(AUDIO_FORMAT_DEFAULT);
-            device->setDeviceConnectState(false);
-
-            // remove device from mReportedFormatsMap cache
-            mReportedFormatsMap.erase(device);
 
             // remove preferred mixer configurations
             mPreferredMixerAttrInfos.erase(device->getId());
@@ -417,6 +409,9 @@ status_t AudioPolicyManager::setDeviceConnectionStateInt(const sp<DeviceDescript
         }
 
         if (state == AUDIO_POLICY_DEVICE_STATE_UNAVAILABLE) {
+            device->setEncodedFormat(AUDIO_FORMAT_DEFAULT);
+            mReportedFormatsMap.erase(device);
+            
             cleanUpForDevice(device);
         }
 


### PR DESCRIPTION
this fixes the issues with BT codecs not playing and users needing to enable in Developer Options "Disable Bluetooth A2DP hardware offload" to work. With this commit, this is not needed anymore
Tested on Pixel 8 Pro with Sony SRS-XB23 with LDAC codec